### PR TITLE
Prepend language token and task id when using multilingual model

### DIFF
--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -1,2 +1,2 @@
 [Flux]
-gpu_backend = "AMD"
+gpu_backend = "AMDGPU"

--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,6 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-AMDGPU = "0.5"
-CUDA = "4.4"
+AMDGPU = "0.8"
+CUDA = "5"
 Flux = "0.14"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ julia> Whisper.transcribe(
     model_name="tiny.en", dev=cpu, precision=f32)
 ```
 
+**Multilingual support**
+
+To perform transcribtion from non-English language,
+specify `language` argument and drop `.en` from the model name.
+
+```julia
+julia> Whisper.transcribe(
+    "ukrainian-sample.flac", "./output.srt";
+    model_name="medium", language="ukrainian", dev=cpu, precision=f32)
+```
+
+To see what languages are supported, execute:
+```julia
+julia> values(Whisper.LANGUAGES)
+```
+
 ## Details
 
 - Supported input file: `.flac` with 1 channel and 16k sample rate.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,8 @@ julia> values(Whisper.LANGUAGES)
 
 - Supported input file: `.flac` with 1 channel and 16k sample rate.
 - Other input files are converted to it using `ffmpeg` which must be installed on your system and accessible from PATH.
-- Only english models are supported right now.
-- Supported model names: `tiny.en`, `base.en`, `small.en`, `medium.en`.
 
 ## TODO
 
 - Beam search decoder.
-- Multilingual support.
 - Streaming support.

--- a/src/Whisper.jl
+++ b/src/Whisper.jl
@@ -52,9 +52,9 @@ end
 
 """
 TODO
-- check for collapse mode, then increase temperature and re-run on segment
-- multilingual
+- support translation
 - detect language
+- check for collapse mode, then increase temperature and re-run on segment
 - streaming
 """
 
@@ -141,27 +141,42 @@ end
 
 function transcribe(
     file_path::String, srt_path::String;
-    model_name::String = "tiny.en",
+    model_name::String = "tiny.en", language::String = "english",
     dev = gpu, precision = f16,
 )
+    if language != "english" && endswith(model_name, ".en")
+        error("""
+            Speicifed language `$language`, but model `$model_name` supports only English.
+            Try dropping `.en` part from the model name.
+            Here's the list of all supported models:
+            $(keys(_MODELS)).
+        """)
+    elseif language == "english" && !endswith(model_name, ".en")
+        error("""
+            For English, use model name that ends with `.en`.
+            Specified name: $model_name.
+            Here's the list of all supported models:
+            $(keys(_MODELS)).
+        """)
+    end
+
     @info "Running on `$dev` device at `$precision` precision."
 
     if endswith(file_path, ".flac")
         waveform, sample_rate::Int = load(file_path)
         if size(waveform, 2) != 1 || sample_rate != SAMPLE_RATE
-            @warn "Running ffmpeg to convert file to a proper format."
             waveform, sample_rate = convert_audio(file_path)
         end
     else
         waveform, sample_rate = convert_audio(file_path)
     end
 
-    log_spec = prep_audio(waveform, sample_rate, 
-        n_mels = model_name=="large-v3" ? N_MELS_V3 : N_MELS ) |> precision
+    log_spec = prep_audio(waveform, sample_rate,
+        n_mels=model_name == "large-v3" ? N_MELS_V3 : N_MELS) |> precision
     content_frames = size(log_spec, 1)
 
     model = WHISPER(model_name) |> precision |> dev
-    tokenizer = BPE(; multilingual= ! endswith(model_name,".en"))
+    tokenizer = BPE(; language)
 
     n_frames = cld(content_frames, N_FRAMES)
     bar = get_pb(n_frames, "Transcribing: ")
@@ -189,9 +204,17 @@ function decode(
     max_context_size = sample_length,
     temperature::Float32 = 0f0,
 )
-    eot_id = tokenizer.special_tokens["<|endoftext|>"]
-    tokens = Int32[tokenizer("<|startoftranscript|>")...] # 0-based idx.
     dev = get_backend(model)
+
+    eot_id = tokenizer.special_tokens["<|endoftext|>"]
+    transcribe_id = tokenizer.special_tokens["<|transcribe|>"]
+    tokens = Int32[tokenizer("<|startoftranscript|>")...] # 0-based idx.
+    # Append tokenizer's language token so that model knows what language it is.
+    # And transcribtion task.
+    if tokenizer.language != "english"
+        push!(tokens, tokens[1] + tokenizer.language_idx)
+        push!(tokens, transcribe_id)
+    end
 
     enc = model.encoder(segment)
     for i in 1:sample_length

--- a/src/audio.jl
+++ b/src/audio.jl
@@ -12,7 +12,7 @@ const N_FRAMES::Int = N_SAMPLES ÷ HOPSIZE # Max frames in mel spectrogram input
 function convert_audio(input_file::String)
     mktempdir() do path
         audio_file = joinpath(path, "whisper-out.flac")
-        run(`ffmpeg -i $input_file -ac 1 -ar 16000 $audio_file`)
+        run(`ffmpeg -nostdin -threads 0 -i $input_file -ac 1 -ar 16000 $audio_file`)
         waveform, sample_rate = load(audio_file)
     end
 end


### PR DESCRIPTION
When using multilingual model we have to prepend `<language id>` + `<task id>` before passing tokens to transcribtion.

- Update deps.
- Update README.